### PR TITLE
WIP: Fix bad tripcubes created

### DIFF
--- a/pymchelper/readers/shieldhit.py
+++ b/pymchelper/readers/shieldhit.py
@@ -484,16 +484,13 @@ class _SHBinaryReader0p1:
         detector.nstat = header['nstat'][0]
 
         if detector.geotyp not in (SHGeoType.zone, SHGeoType.dzone):
-            shift = 0
-            if 'VOXSCORE' in header['geotyp'][0].decode('ascii'):
-                shift = 1  # TODO to be investigated
-            detector.xmin = header['det'][0][0 + shift]
-            detector.ymin = header['det'][0][1 + shift]
-            detector.zmin = header['det'][0][2 + shift]
+            detector.xmin = header['det'][0][0]
+            detector.ymin = header['det'][0][1]
+            detector.zmin = header['det'][0][2]
 
-            detector.xmax = header['det'][0][3 + shift]
-            detector.ymax = header['det'][0][4 + shift]
-            detector.zmax = header['det'][0][5 + shift]
+            detector.xmax = header['det'][0][3]
+            detector.ymax = header['det'][0][4]
+            detector.zmax = header['det'][0][5]
         else:
             # special case for zone scoring, x min and max will be zone numbers
             detector.xmin = det_attribs.starting_zone

--- a/pymchelper/writers/trip98.py
+++ b/pymchelper/writers/trip98.py
@@ -1,8 +1,9 @@
 import time
 import logging
 import os
-
 import numpy as np
+from pymchelper import __version__ as _pmcversion
+from pytrip import __version__ as _ptversion
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,12 @@ class TripCubeWriter:
 
         logging.debug("psx: {:.6f} [cm]".format(pixel_size_x))
         logging.debug("psz: {:.6f} [cm]".format(pixel_size_z))
-        
+
+        _patient_name = "Anonymous"
+        _created_by = "PyTRiP98"  # TODO: substitute this by username
+        _creation_info = "Created with pymchelper {:s}; using PyTRiP98 {:s}".format(_pmcversion,
+                                                                                    _ptversion)
+
         if detector.dettyp == SHDetType.dose:
 
             from pytrip import dos
@@ -46,6 +52,11 @@ class TripCubeWriter:
             else:
                 cube.cube = (cube.cube / cube.cube.max()) * 1200.0
 
+            # Save proper meta information
+            cube.patient_name = _patient_name
+            cube.created_by = _created_by
+            cube.creation_info = _creation_info
+
             cube.write(self.output_corename)
 
         elif detector.dettyp in (SHDetType.dlet, SHDetType.tlet, SHDetType.dletg, SHDetType.tletg):
@@ -57,7 +68,7 @@ class TripCubeWriter:
             cube.create_empty_cube(
                 1.0, detector.nx, detector.ny, detector.nz,
                 pixel_size=pixel_size_x * 10.0,
-                slice_distance=pixel_size_z *10.0)
+                slice_distance=pixel_size_z * 10.0)
 
             # .dosemlet.dos LET cubes are usually in 32 bit floats.
             cube.data_type = "float"
@@ -71,9 +82,13 @@ class TripCubeWriter:
 
             cube.cube = detector.data.reshape(detector.nx, detector.ny, detector.nz)
             cube.cube *= 0.1  # MeV/cm -> keV/um
+            # Save proper meta information
+
+            cube.patient_name = _patient_name
+            cube.created_by = _created_by
+            cube.creation_info = _creation_info
 
             cube.write(self.output_corename)
-
         else:
             logger.error("Tripcube target is only allowed with dose- or LET-type detectors.")
             raise Exception("Illegal detector for tripcube.")

--- a/pymchelper/writers/trip98.py
+++ b/pymchelper/writers/trip98.py
@@ -2,8 +2,6 @@ import time
 import logging
 import os
 import numpy as np
-from pymchelper import __version__ as _pmcversion
-from pytrip import __version__ as _ptversion
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +11,11 @@ class TripCubeWriter:
         self.output_corename = filename
 
     def write(self, detector):
+        import getpass
         from pymchelper.shieldhit.detector.detector_type import SHDetType
+        from pymchelper import __version__ as _pmcversion
+        # TODO add printing information how to install pytrip if it's missing
+        from pytrip import __version__ as _ptversion
 
         pixel_size_x = (detector.xmax - detector.xmin) / detector.nx
         pixel_size_z = (detector.zmax - detector.zmin) / detector.nz
@@ -22,7 +24,7 @@ class TripCubeWriter:
         logging.debug("psz: {:.6f} [cm]".format(pixel_size_z))
 
         _patient_name = "Anonymous"
-        _created_by = "PyTRiP98"  # TODO: substitute this by username
+        _created_by = getpass.getuser()
         _creation_info = "Created with pymchelper {:s}; using PyTRiP98 {:s}".format(_pmcversion,
                                                                                     _ptversion)
 
@@ -78,7 +80,7 @@ class TripCubeWriter:
             # need to redo the cube, since by default np.float32 are allocated.
             # When https://github.com/pytrip/pytrip/issues/35 is fixed,
             # then this should not be needed.
-            cube.cube = np.ones((cube.dimz, cube.dimy, cube.dimx), dtype=cube.pydata_type) * (1.0)
+            cube.cube = np.ones((cube.dimz, cube.dimy, cube.dimx), dtype=cube.pydata_type)
 
             cube.cube = detector.data.reshape(detector.nx, detector.ny, detector.nz)
             cube.cube *= 0.1  # MeV/cm -> keV/um

--- a/pymchelper/writers/trip98.py
+++ b/pymchelper/writers/trip98.py
@@ -17,13 +17,19 @@ class TripCubeWriter:
         pixel_size_x = (detector.xmax - detector.xmin) / detector.nx
         pixel_size_z = (detector.zmax - detector.zmin) / detector.nz
 
+        logging.debug("psx: {:.6f} [cm]".format(pixel_size_x))
+        logging.debug("psz: {:.6f} [cm]".format(pixel_size_z))
+        
         if detector.dettyp == SHDetType.dose:
 
             from pytrip import dos
 
             cube = dos.DosCube()
+            # Warning: PyTRiP cube dimensions are in [mm]
             cube.create_empty_cube(
-                1.0, detector.nx, detector.ny, detector.nz, pixel_size=pixel_size_x, slice_distance=pixel_size_z)
+                1.0, detector.nx, detector.ny, detector.nz,
+                pixel_size=pixel_size_x * 10.0,
+                slice_distance=pixel_size_z * 10.0)
 
             # .dos dose cubes are usually in normalized integers,
             # where "1000" equals 100.0 % dose.
@@ -47,8 +53,11 @@ class TripCubeWriter:
             from pytrip import let
 
             cube = let.LETCube()
+            # Warning: PyTRiP cube dimensions are in [mm]
             cube.create_empty_cube(
-                1.0, detector.nx, detector.ny, detector.nz, pixel_size=pixel_size_x, slice_distance=pixel_size_z)
+                1.0, detector.nx, detector.ny, detector.nz,
+                pixel_size=pixel_size_x * 10.0,
+                slice_distance=pixel_size_z *10.0)
 
             # .dosemlet.dos LET cubes are usually in 32 bit floats.
             cube.data_type = "float"


### PR DESCRIPTION
fixes #174 
- [x] slice distance seems to be filled with a bogus value
- [x] also "Anonymous" is spelled wrong.
- [x] add pymchelper and PyTRiP version number to creation info, and check spelling "created"
- [x] use proper case of PyTRiP98
-  [x] pixel size is a factor 10 wrong