### PR TITLE
Include py 3.6 in travis testing suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,6 @@ matrix:
 #    uncomment and adjust if you want to allow some failures
     allow_failures:
         - os: linux
-          python: 3.6
-          env: TOXENV=py36
-        - os: linux
           python: nightly
           env: TOXENV=py37
 


### PR DESCRIPTION
https://www.python.org/downloads/release/python-360/ released on 23.12.2016
