### PR TITLE
bring back old-style numpy printing style,

### DIFF
--- a/pymchelper/detector.py
+++ b/pymchelper/detector.py
@@ -3,6 +3,7 @@ from enum import IntEnum
 import logging
 
 import numpy as np
+np.set_printoptions(legacy="1.13")
 
 logger = logging.getLogger(__name__)
 

--- a/pymchelper/detector.py
+++ b/pymchelper/detector.py
@@ -3,7 +3,12 @@ from enum import IntEnum
 import logging
 
 import numpy as np
-np.set_printoptions(legacy="1.13")
+# try to set legacy printing options if working with numpy 1.14 or newer
+# on older numpy versions this shouldn't have effect
+try:
+    np.set_printoptions(legacy="1.13")
+except TypeError as e:
+    pass
 
 logger = logging.getLogger(__name__)
 

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -3,7 +3,6 @@ versioneer<0.18
 # pytest v 3.0, released in 08.2016 doesn't work well with Python 3.2
 pytest<3.0 ; python_version >= '3.2' and python_version < '3.4' or os_name == 'nt' # py 3.2 or 3.3
 pytest ; (python_version < '3.0' or python_version >= '3.4') and os_name != 'nt' # py different than 3.2 or 3.3
-pytest-catchlog
 pytest-timeout
 pytest-xdist ; (python_version < '3.0' or python_version >= '3.4') and os_name != 'nt' # py different than 3.2
 pytest-xdist<1.18.0  ; python_version >= '3.2' and python_version < '3.4' or os_name == 'nt' # py 3.2, 3.3 or Wind


### PR DESCRIPTION
new one, introduced in numpy 1.14 is braking the tests

removed pytest-catchlog from deps to fix the warning saying that
"has been merged into the core, please remove it from your requirements"

Fixes #283 