### PR TITLE
My initial attempt to decompress bdz-file and pass it on

### DIFF
--- a/pymchelper/readers/shieldhit/general.py
+++ b/pymchelper/readers/shieldhit/general.py
@@ -14,7 +14,7 @@ from pymchelper.readers.shieldhit.binary_spec import SHBDOTagID
 logger = logging.getLogger(__name__)
 
 
-def file_has_sh_magic_number(filename):
+def file_has_sh_magic_number(bdo):
     """
     BDO binary files, introduced in 2016 (BDO2016 and BDO2019 formats) starts with 6 magic bytes xSH12A
     :param filename: Binary file filename
@@ -22,13 +22,12 @@ def file_has_sh_magic_number(filename):
     """
     sh_bdo_magic_number = b'xSH12A'
     has_bdo_magic_number = False
-    with open(filename, "rb") as f:
-        # TODO add a check if file has less than 6 bytes or is empty
-        d1 = np.dtype([('magic', 'S6')])
-        x = np.fromfile(f, dtype=d1, count=1)
-        if x:
-            # compare first 6 bytes with reference string
-            has_bdo_magic_number = (sh_bdo_magic_number == x['magic'][0])
+    # TODO add a check if file has less than 6 bytes or is empty
+    d1 = np.dtype([('magic', 'S6')])
+    x = np.frombuffer(bdo, dtype=d1, count=1)
+    if x:
+        # compare first 6 bytes with reference string
+        has_bdo_magic_number = (sh_bdo_magic_number == x['magic'][0])
 
     logger.debug("File {:s} has magic number: {:s}".format(filename, str(has_bdo_magic_number)))
     return has_bdo_magic_number
@@ -136,7 +135,7 @@ class SHReaderFactory(ReaderFactory):
 
         # magic number was introduced together with first token-based BDO file format (BDO2016)
         # presence of magic number means we could have BDO2016 or BDO2019 format
-        if file_has_sh_magic_number(self.filename):
+        if file_has_sh_magic_number(bdo):
             reader = SHReaderBDO2019
 
             # format tag specifying binary standard was introduced in SH12A v0.7.4-dev on  07.06.2019 (commit 6eddf98)

--- a/pymchelper/readers/shieldhit/general.py
+++ b/pymchelper/readers/shieldhit/general.py
@@ -127,14 +127,12 @@ class SHReaderFactory(ReaderFactory):
         # Trying to decompress bdz-file. If it works, saves a temporary bdo-file which will be used for reading later
         # zip_name is the addition to the file name for the new bdo-file, compared to the original: nothing in case
         # original is already bdo, and "_TEMP.bdo" in case original was a bdz.
-        with open(self.filename) as f:
+
+        with open(self.filename, "rb") as f:
             try:
-                bdo_unzip = zlib.decompress(f.read())
-                zip_name = '_TEMP.bdo'
-                with open(self.filename + zip_name, 'w') as file:
-                    file.write(bdo_unzip)
-            except UnicodeDecodeError:
-                zip_name = ''
+                bdo = zlib.decompress(f.read())
+            except zlib.error:
+                bdo = f.read()
 
         # magic number was introduced together with first token-based BDO file format (BDO2016)
         # presence of magic number means we could have BDO2016 or BDO2019 format


### PR DESCRIPTION
I have spent some time on this (not resulted in much code). My idea to fix the support the bdz files is to:
1. Try to decompress the current file using zlib.decompress. If it works, save a temporary bdo-file
2. Create a string variable (called zip_name here), which is passed on to the next functions along with self.filename. This is empty if original file is bdo (so name does not change), otherwise the "_TEMP.bdo" is added so it instead points to the saved temporary bdo-file.
3. After all is done, delete the temporary bdo-file

In my submitted code, I have only tried to implement 1-2 (though not yet changed how the string with the filename is passed on)

The problems I have:
1. I cannot decompress the bdz-file using zlib.decompress method. It gives me the error:
"UnicodeDecodeError: 'utf-8' codec can't decode byte 0xab in position 2: invalid start byte"
As the file type is quite unique, I did not find much googling for the solution

2. Before I go further trying to implement it in detail, do you think this approach in general is good? It may be "un-clean" to pass around the string. (Please be direct and honest)