### PR TITLE
dropping support for old Python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,23 +43,13 @@ jobs:
   normal_test:
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         platform: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - platform: macos-latest
-            python-version: 3.5
-          - platform: macos-latest
-            python-version: 3.6
-          - platform: macos-latest
-            python-version: 3.7
           - platform: macos-latest
             python-version: 3.8
           - platform: macos-latest
             python-version: 3.10
-          - platform: windows-latest
-            python-version: 3.5
-          - platform: windows-latest
-            python-version: 3.6
     runs-on: ${{ matrix.platform }}
     needs: [smoke_test]
     steps:

--- a/.github/workflows/release-pip.yml
+++ b/.github/workflows/release-pip.yml
@@ -15,7 +15,7 @@ jobs:
   full_test:
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/pymchelper/__init__.py
+++ b/pymchelper/__init__.py
@@ -1,11 +1,7 @@
+import importlib
+import importlib.util
 import os
-import sys
 
-# Python2 lacks a FileNotFoundError exception, we use then IOError
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
 
 __version__ = 'unknown'
 
@@ -19,14 +15,8 @@ __version__ = 'unknown'
 
 # get location of __init__.py file (the one you see now) in the filesystem
 module_name = 'pymchelper'
-if sys.version_info < (3, 0):  # Python 2.7
-    import imp
-    init_location = os.path.join(imp.find_module(module_name)[1], module_name)
-else:  # Python 3.x
-    import importlib
-    import importlib.util
-    spec = importlib.util.find_spec(module_name)
-    init_location = spec.origin
+spec = importlib.util.find_spec(module_name)
+init_location = spec.origin
 
 # VERSION should sit next to __init__.py in the directory structure
 version_file = os.path.join(os.path.dirname(init_location), 'VERSION')

--- a/setup.py
+++ b/setup.py
@@ -76,11 +76,6 @@ install_requires = [
     "numpy>=1.21 ; python_version == '3.10'",
     "numpy>=1.20 ; python_version == '3.9'",
     "numpy>=1.18 ; python_version == '3.8'",
-    "numpy>=1.15 ; python_version == '3.7'",
-    "numpy>=1.12,<1.20 ; python_version == '3.6'",
-    "numpy>=1.11,<1.19 ; python_version == '3.5'",
-    "numpy>=1.11,<1.16 ; python_version == '3.4' or python_version == '2.7'",
-    "enum34 ; python_version == '3.4' or python_version == '2.7'"
 ]
 
 setuptools.setup(
@@ -117,11 +112,6 @@ setuptools.setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -137,5 +127,5 @@ setuptools.setup(
     package_data={'pymchelper': ['flair/db/*', 'VERSION']},
     install_requires=install_requires,
     extras_require=EXTRAS_REQUIRE,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
This PR drops support for python versions older than 3.8, following the plan from https://github.com/DataMedSci/pymchelper/issues/418

Right now deb package repository and single executable devliery seems to be working, so this would be a safe option for Linux users without access to modern python