### PR TITLE
faster MCPL writing using numpy

### DIFF
--- a/pymchelper/input_output.py
+++ b/pymchelper/input_output.py
@@ -94,6 +94,7 @@ def fromfilelist(input_file_list, error: ErrorEstimate = ErrorEstimate.stderr, n
         # loop over all files with n running from 2
         for n, filename in enumerate(input_file_list[1:], start=2):
             current_estimator = fromfile(filename)  # x
+            logger.info("Reading file %s (%d/%d)", filename, n, len(input_file_list))
 
             if not current_estimator:
                 logger.warning("File %s could not be read", filename)
@@ -102,10 +103,10 @@ def fromfilelist(input_file_list, error: ErrorEstimate = ErrorEstimate.stderr, n
             for current_page, result_page in zip(current_estimator.pages, result.pages):
                 # got a page with "concatenate normalisation"
                 if getattr(current_page, 'page_normalized', 2) == 4:
-                    logger.info("Concatenating page %s", current_page.name)
+                    logger.debug("Concatenating page %s", current_page.name)
                     result_page.data_raw = np.concatenate((result_page.data_raw, current_page.data_raw))
                 else:
-                    logger.info("Averaging page %s", current_page.name)
+                    logger.debug("Averaging page %s", current_page.name)
                     # Running variance algorithm based on algorithm by B. P. Welford,
                     # presented in Donald Knuth's Art of Computer Programming, Vol 2, page 232, 3rd edition.
                     # Can be found here: http://www.johndcook.com/blog/standard_deviation/

--- a/pymchelper/readers/shieldhit/binary_spec.py
+++ b/pymchelper/readers/shieldhit/binary_spec.py
@@ -125,6 +125,8 @@ class SHBDOTagID(IntEnum):
     #          two %s are the differential units, and the first is the data in
     #          non-differential form. */
 
+    phase_space_population = 0xDDE0  # /* number of particles in phase space */
+
     # /* Filter data attached to page */
     page_filter_name = 0xDDF0  # /* name of filter containing one or more rules */
     page_filter_rules_no = 0xDDF1  # /* number of filter rules applied */
@@ -159,9 +161,7 @@ class SHBDOTagID(IntEnum):
     error = 0xFFCE  # /* 0xFFCE-rror */
 
 
-estimator_tags_to_save = (
-
-)
+estimator_tags_to_save = ()
 
 page_tags_to_save = (
     SHBDOTagID.detector_type,
@@ -170,16 +170,13 @@ page_tags_to_save = (
     SHBDOTagID.page_scale_factor,
     SHBDOTagID.page_offset,
     SHBDOTagID.page_unit_ids,
-
     SHBDOTagID.detector_unit,
-
     SHBDOTagID.page_diff_flag,
     SHBDOTagID.page_diff_type,
     SHBDOTagID.page_diff_start,
     SHBDOTagID.page_diff_stop,
     SHBDOTagID.page_diff_size,
     SHBDOTagID.page_diff_units,
-
     SHBDOTagID.page_filter_name,
     SHBDOTagID.page_filter_rules_no,
     SHBDOTagID.page_filter_e_min,
@@ -281,28 +278,23 @@ unit_name_from_unit_id = {
     SHBDOUnitID.SH_SCORING_UNIT_PCT: "%",
     SHBDOUnitID.SH_SCORING_UNIT_PMIL: "%%",
     SHBDOUnitID.SH_SCORING_UNIT_RELATIVE: "rel.units",
-
     SHBDOUnitID.SH_SCORING_UNIT_CM: "cm",
     SHBDOUnitID.SH_SCORING_UNIT_CM2: "cm^2",
     SHBDOUnitID.SH_SCORING_UNIT_CM3: "cm^3",
     SHBDOUnitID.SH_SCORING_UNIT_PCM: "/cm",
     SHBDOUnitID.SH_SCORING_UNIT_PCM2: "/cm^2",
     SHBDOUnitID.SH_SCORING_UNIT_PCM3: "/cm^3",
-
     SHBDOUnitID.SH_SCORING_UNIT_M: "m",
     SHBDOUnitID.SH_SCORING_UNIT_M2: "m^2",
     SHBDOUnitID.SH_SCORING_UNIT_M3: "m^3",
     SHBDOUnitID.SH_SCORING_UNIT_PM: "/m",
     SHBDOUnitID.SH_SCORING_UNIT_PM2: "/m^2",
     SHBDOUnitID.SH_SCORING_UNIT_PM3: "/m^3",
-
     SHBDOUnitID.SH_SCORING_UNIT_GPCM3: "g/cm^3",
     SHBDOUnitID.SH_SCORING_UNIT_KGPM3: "kg/m^3",
-
     SHBDOUnitID.SH_SCORING_UNIT_KEVPUM: "keV/um",
     SHBDOUnitID.SH_SCORING_UNIT_MEVPCM: "MeV/cm",
     SHBDOUnitID.SH_SCORING_UNIT_MEVCM2PG: "MeV cm^2/g",
-
     SHBDOUnitID.SH_SCORING_UNIT_MEVPG: "MeV/g",
     SHBDOUnitID.SH_SCORING_UNIT_GY: "Gy",
     SHBDOUnitID.SH_SCORING_UNIT_GYRBE: "Gy(RBE)",  # /* Probably there are new ICRU rules here */
@@ -310,21 +302,16 @@ unit_name_from_unit_id = {
     SHBDOUnitID.SH_SCORING_UNIT_SV: "Sv",
     SHBDOUnitID.SH_SCORING_UNIT_DOSERAD: "Rad",
     SHBDOUnitID.SH_SCORING_UNIT_DOSEREM: "Rem",
-
     SHBDOUnitID.SH_SCORING_UNIT_DEGREES: "deg",
     SHBDOUnitID.SH_SCORING_UNIT_RADIANS: "rad",
     SHBDOUnitID.SH_SCORING_UNIT_SR: "sr",
-
     SHBDOUnitID.SH_SCORING_UNIT_COUNT: "#",
-
     SHBDOUnitID.SH_SCORING_UNIT_MEV: "MeV",
     SHBDOUnitID.SH_SCORING_UNIT_MEVPNUC: "MeV/nucleon",
     SHBDOUnitID.SH_SCORING_UNIT_MEVPAMU: "MeV/amu",
-
     SHBDOUnitID.SH_SCORING_UNIT_NUCN: "",
     SHBDOUnitID.SH_SCORING_UNIT_MEVPC2: "MeV/c^2",
     SHBDOUnitID.SH_SCORING_UNIT_U: "u",
-
     SHBDOUnitID.SH_SCORING_UNIT_MATID: "",
     SHBDOUnitID.SH_SCORING_UNIT_NZONE: "",
 }

--- a/pymchelper/writers/mcpl.py
+++ b/pymchelper/writers/mcpl.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 import struct
+
+import numpy as np
 import pymchelper
 
 from pymchelper.page import Page
@@ -50,37 +52,80 @@ class MCPLWriter(Writer):
             # iterate over rows in the data array page.data
             # need to fix the structure according to MCPL format
             # see https://mctools.github.io/mcpl/mcpl.pdf#nameddest=section.3
-            for row in page.data.T:
-                pdg, x, y, z, ux, uy, uz, E = row
 
-                # adaptive projection packing
-                fp1: float = float('nan')
-                fp2: float = float('nan')
-                sign: int = 1
-                if ux * ux > uy * uy and ux * ux > uz * uz:
-                    if ux < 0:
-                        sign = -1
-                    fp1 = 1 / uz
-                    fp2 = uy
-                if uy * uy > ux * ux and uy * uy > uz * uz:
-                    if uy < 0:
-                        sign = -1
-                    fp1 = ux
-                    fp2 = 1 / uz
-                if uz * uz >= ux * ux and uz * uz >= uy * uy:
-                    if uz < 0:
-                        sign = -1
-                    fp1 = ux
-                    fp2 = uy
+            print(page.data.shape)
+            pdg = page.data[0]
+            x = page.data[1]
+            y = page.data[2]
+            z = page.data[3]
+            ux = page.data[4]
+            uy = page.data[5]
+            uz = page.data[6]
+            E = page.data[7]
+            fp1 = np.empty_like(ux)
+            fp2 = np.empty_like(uy)
+            sign = np.ones_like(x, dtype=int)
 
-                bytes_to_write += struct.pack("<f", x)  # x
-                bytes_to_write += struct.pack("<f", y)  # y
-                bytes_to_write += struct.pack("<f", z)  # z
-                bytes_to_write += struct.pack("<f", fp1)  # FP1 (mostly ux)
-                bytes_to_write += struct.pack("<f", fp2)  # FP2 (mostly uy)
-                bytes_to_write += struct.pack("<f", sign * E)  # uz
-                bytes_to_write += struct.pack("<f", 0)  # time
-                bytes_to_write += struct.pack("<I", int(pdg))  # pdg
+            condition_1 = np.logical_and(np.logical_and(ux * ux > uy * uy, ux * ux > uz * uz), ux < 0)
+            condition_2 = np.logical_and(np.logical_and(uy * uy > ux * ux, uy * uy > uz * uz), uy < 0)
+            condition_3 = np.logical_and(np.logical_and(uz * uz >= ux * ux, uz * uz >= uy * uy), uz < 0)
+
+            sign[ux < 0] = -1
+            fp1[condition_1] = 1 / uz[condition_1]
+            fp2[condition_1] = uy[condition_1]
+
+            sign[uy < 0] = -1
+            fp1[condition_2] = ux[condition_2]
+            fp2[condition_2] = 1 / uz[condition_2]
+
+            sign[uz < 0] = -1
+            fp1[condition_3] = ux[condition_3]
+            fp2[condition_3] = uy[condition_3]
+
+            bytes_to_write = np.empty(page.data.shape, dtype=np.float32)
+            bytes_to_write[0] = x
+            bytes_to_write[1] = y
+            bytes_to_write[2] = z
+            bytes_to_write[3] = fp1
+            bytes_to_write[4] = fp2
+            bytes_to_write[5] = sign * E
+            bytes_to_write[6] = 0
+            bytes_to_write[7] = pdg.astype(np.uint32)
+
+            bytes_to_write = bytes_to_write.tobytes()
+
+            # for i, row in enumerate(page.data.T):
+
+            #     pdg, x, y, z, ux, uy, uz, E = row
+
+            #     # adaptive projection packing
+            #     fp1: float = float('nan')
+            #     fp2: float = float('nan')
+            #     sign: int = 1
+            #     if ux * ux > uy * uy and ux * ux > uz * uz:
+            #         if ux < 0:
+            #             sign = -1
+            #         fp1 = 1 / uz
+            #         fp2 = uy
+            #     if uy * uy > ux * ux and uy * uy > uz * uz:
+            #         if uy < 0:
+            #             sign = -1
+            #         fp1 = ux
+            #         fp2 = 1 / uz
+            #     if uz * uz >= ux * ux and uz * uz >= uy * uy:
+            #         if uz < 0:
+            #             sign = -1
+            #         fp1 = ux
+            #         fp2 = uy
+
+            #     bytes_to_write += struct.pack("<f", x)  # x
+            #     bytes_to_write += struct.pack("<f", y)  # y
+            #     bytes_to_write += struct.pack("<f", z)  # z
+            #     bytes_to_write += struct.pack("<f", fp1)  # FP1 (mostly ux)
+            #     bytes_to_write += struct.pack("<f", fp2)  # FP2 (mostly uy)
+            #     bytes_to_write += struct.pack("<f", sign * E)  # uz
+            #     bytes_to_write += struct.pack("<f", 0)  # time
+            #     bytes_to_write += struct.pack("<I", int(pdg))  # pdg
 
             output_path.write_bytes(bytes_to_write)
             return

--- a/pymchelper/writers/mcpl.py
+++ b/pymchelper/writers/mcpl.py
@@ -99,38 +99,5 @@ class MCPLWriter(Writer):
 
             data_bytes = data_bytes.tobytes()
 
-            # for i, row in enumerate(page.data.T):
-
-            #     pdg, x, y, z, ux, uy, uz, E = row
-
-            #     # adaptive projection packing
-            #     fp1: float = float('nan')
-            #     fp2: float = float('nan')
-            #     sign: int = 1
-            #     if ux * ux > uy * uy and ux * ux > uz * uz:
-            #         if ux < 0:
-            #             sign = -1
-            #         fp1 = 1 / uz
-            #         fp2 = uy
-            #     if uy * uy > ux * ux and uy * uy > uz * uz:
-            #         if uy < 0:
-            #             sign = -1
-            #         fp1 = ux
-            #         fp2 = 1 / uz
-            #     if uz * uz >= ux * ux and uz * uz >= uy * uy:
-            #         if uz < 0:
-            #             sign = -1
-            #         fp1 = ux
-            #         fp2 = uy
-
-            #     bytes_to_write += struct.pack("<f", x)  # x
-            #     bytes_to_write += struct.pack("<f", y)  # y
-            #     bytes_to_write += struct.pack("<f", z)  # z
-            #     bytes_to_write += struct.pack("<f", fp1)  # FP1 (mostly ux)
-            #     bytes_to_write += struct.pack("<f", fp2)  # FP2 (mostly uy)
-            #     bytes_to_write += struct.pack("<f", sign * E)  # uz
-            #     bytes_to_write += struct.pack("<f", 0)  # time
-            #     bytes_to_write += struct.pack("<I", int(pdg))  # pdg
-
             output_path.write_bytes(header_bytes + data_bytes)
             return

--- a/pymchelper/writers/mcpl.py
+++ b/pymchelper/writers/mcpl.py
@@ -78,18 +78,19 @@ class MCPLWriter(Writer):
             # condition below defines the case where the maximum component is uy
             condition_2 = np.logical_and(uy2 > ux2, uy2 > uz2)
             # by exclusion, the remaining case is where the maximum component is uz
+            condition_3 = np.logical_not(np.logical_or(condition_1, condition_2))
 
             # fill the arrays according to the maximum component
             # lets start with the case where the maximum component is uz
-            sign[page.data[6] < 0] = -1
+            sign[(page.data[6] < 0) & condition_3] = -1
 
             # fill the arrays according to the maximum component ux
-            sign[page.data[4] < 0] = -1  # negative sign of ux
+            sign[(page.data[4] < 0) & condition_1] = -1  # negative sign of ux
             data_bytes['fp1'][condition_1] = 1 / page.data[6][condition_1]  # 1/uz
             data_bytes['fp2'][condition_1] = page.data[5][condition_1]  # uy
 
             # fill the arrays according to the maximum component uy
-            sign[page.data[5] < 0] = -1  # sign of uy
+            sign[(page.data[5] < 0) & condition_2] = -1  # sign of uy
             data_bytes['fp1'][condition_2] = page.data[4][condition_2]  # ux
             data_bytes['fp2'][condition_2] = 1 / page.data[6][condition_2]  # 1/uz
 

--- a/tests/test_mcpl.py
+++ b/tests/test_mcpl.py
@@ -106,6 +106,7 @@ def test_mcpl_generation(phasespace_bdo_file_path: Path, tmp_path: Path, monkeyp
             assert p.weight == 1.0
             assert p.pdgcode == 2212  # protons
             assert p.position[2] == 4.0
+            assert p.direction[2] > 0.0
 
 
 def test_concatenation_of_bdo_files(phasespace_bdo_files_path: Generator[Path, None, None]):


### PR DESCRIPTION
It seems for large files we would need to use numpy instead of pure python.
For 100 files with 10^7 particles, conversion with numpy to MCPL takes about 2 min, resulting in 3 GB phasespace file. Pure python takes weeks