### PR TITLE
Fix problems with dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ EXTRAS_REQUIRE['full'].extend(["hipsterplot", "bashplotlib"])  # these are neede
 # |---------------------------------------------------|
 # | numpy version | python versions |    OS support   |
 # |---------------------------------------------------|
+# |      1.26     |    3.9 - 3.12   | linux, mac, win |
+# |      1.25     |    3.9 - 3.11   | linux, mac, win |
 # |      1.24     |    3.8 - 3.11   | linux, mac, win |
 # |     1.23.3    |    3.8 - 3.11   | linux, mac, win |
 # | 1.22 - 1.23.2 |    3.8 - 3.10   | linux, mac, win |

--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,9 @@ EXTRAS_REQUIRE['full'].extend(["hipsterplot", "bashplotlib"])  # these are neede
 # |---------------------------------------------------|
 # see https://www.python.org/dev/peps/pep-0508/ for language specification
 install_requires = [
-    "numpy>=1.23.3,<1.26.0 ; python_version == '3.11'",
-    "numpy>=1.21,<1.26.0 ; python_version == '3.10'",
-    "numpy>=1.20,<1.26.0 ; python_version == '3.9'",
+    "numpy>=1.23.3 ; python_version == '3.11'",
+    "numpy>=1.21 ; python_version == '3.10'",
+    "numpy>=1.20 ; python_version == '3.9'",
     "numpy>=1.18,<1.26.0 ; python_version == '3.8'",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,10 +76,10 @@ EXTRAS_REQUIRE['full'].extend(["hipsterplot", "bashplotlib"])  # these are neede
 # |---------------------------------------------------|
 # see https://www.python.org/dev/peps/pep-0508/ for language specification
 install_requires = [
-    "numpy>=1.23.3 ; python_version == '3.11'",
-    "numpy>=1.21 ; python_version == '3.10'",
-    "numpy>=1.20 ; python_version == '3.9'",
-    "numpy>=1.18 ; python_version == '3.8'",
+    "numpy>=1.23.3,<1.26.0 ; python_version == '3.11'",
+    "numpy>=1.21,<1.26.0 ; python_version == '3.10'",
+    "numpy>=1.20,<1.26.0 ; python_version == '3.9'",
+    "numpy>=1.18,<1.26.0 ; python_version == '3.8'",
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ EXTRAS_REQUIRE = {
     ],
     'pytrip': [
         'scipy',
+        "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.11'; <3.9.0",
+        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.10' and python_version < '3.11'",
+        "pytrip98<3.9.0 ; platform_system == 'darwin' and python_version >= '3.5' and python_version < '3.10'"
         "pytrip98>=3.8.0 ; python_version >= '3.11'",
         "pytrip98>=3.6.1 ; python_version >= '3.10' and python_version < '3.11'",
         "pytrip98 ; python_version >= '3.5' and python_version < '3.10'"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ EXTRAS_REQUIRE = {
     'pytrip': [
         'scipy',
         "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.11'",
-        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.10' and python_version < '3.11')",
+        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.10' and python_version < '3.11')", # noqa: E501
         "pytrip98<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.5' and python_version < '3.10')",
         "pytrip98>=3.8.0 ; python_version >= '3.11'",
         "pytrip98>=3.6.1 ; python_version >= '3.10' and python_version < '3.11'",

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ EXTRAS_REQUIRE = {
     ],
     'pytrip': [
         'scipy',
-        "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.11'",
-        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.10' and python_version < '3.11')", # noqa: E501
-        "pytrip98<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.5' and python_version < '3.10')",
+        "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'Darwin' and python_version >= '3.11'",
+        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'Darwin' and (python_version >= '3.10' and python_version < '3.11')", # noqa: E501
+        "pytrip98<3.9.0 ; platform_system == 'Darwin' and (python_version >= '3.5' and python_version < '3.10')",
         "pytrip98>=3.8.0 ; python_version >= '3.11'",
         "pytrip98>=3.6.1 ; python_version >= '3.10' and python_version < '3.11'",
         "pytrip98 ; python_version >= '3.5' and python_version < '3.10'"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ EXTRAS_REQUIRE = {
     'pytrip': [
         'scipy',
         "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'Darwin' and python_version >= '3.11'",
-        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'Darwin' and (python_version >= '3.10' and python_version < '3.11')", # noqa: E501
+        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'Darwin' and (python_version >= '3.10' and python_version < '3.11')",  # noqa: E501
         "pytrip98<3.9.0 ; platform_system == 'Darwin' and (python_version >= '3.5' and python_version < '3.10')",
         "pytrip98>=3.8.0 ; python_version >= '3.11'",
         "pytrip98>=3.6.1 ; python_version >= '3.10' and python_version < '3.11'",

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ EXTRAS_REQUIRE = {
     ],
     'pytrip': [
         'scipy',
-        "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.11'; <3.9.0",
-        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.10' and python_version < '3.11'",
-        "pytrip98<3.9.0 ; platform_system == 'darwin' and python_version >= '3.5' and python_version < '3.10'"
+        "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'darwin' and python_version >= '3.11'",
+        "pytrip98>=3.6.1,<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.10' and python_version < '3.11')",
+        "pytrip98<3.9.0 ; platform_system == 'darwin' and (python_version >= '3.5' and python_version < '3.10')",
         "pytrip98>=3.8.0 ; python_version >= '3.11'",
         "pytrip98>=3.6.1 ; python_version >= '3.10' and python_version < '3.11'",
         "pytrip98 ; python_version >= '3.5' and python_version < '3.10'"
@@ -83,7 +83,7 @@ EXTRAS_REQUIRE['full'].extend(["hipsterplot", "bashplotlib"])  # these are neede
 install_requires = [
     "numpy>=1.23.3 ; python_version == '3.11'",
     "numpy>=1.21 ; python_version == '3.10'",
-    "numpy>=1.20 ; python_version == '3.9'",
+    "numpy>=1.20,<1.26.0 ; python_version == '3.9'",
     "numpy>=1.18,<1.26.0 ; python_version == '3.8'",
 ]
 


### PR DESCRIPTION
We have to resolve some issues with NumPy and other dependencies.

In this pipeline (https://github.com/DataMedSci/pymchelper/actions/runs/6342276507/job/17227689169?pr=656).
Pipeline runs Python 3.9 on MacOS.

pip cannot resolve dependencies for packages specified below:
- numpy-1.26.0-cp39-cp39-macosx_10_9_x86_64.whl.metadata 
- scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl.metadata 
- h5py-3.9.0-cp39-cp39-macosx_10_9_x86_64.whl.metadata
- xlwt-1.3.0-py2.py3-none-any.whl
- matplotlib-3.8.0-cp39-cp39-macosx_10_12_x86_64.whl.metadata
- hipsterplot-0.1-py2.py3-none-any.whl
- bashplotlib-0.6.5.tar.gz
- pydicom-2.4.3-py3-none-any.whl.metadata
- pytrip98-3.9.0.tar.gz

About NumPy, according to https://numpy.org/doc/stable/release/1.25.0-notes.html version 1.25.0 and 1.26.0 does not support Python 3.8.
```
The Python versions supported in this release are 3.9-3.11.
```
