### PR TITLE
Fix line code block in Get started section

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -62,11 +62,11 @@ We assume you are familiar with GIT source control system.
     $ cd pymchelper
     $ git checkout -b feature/issue_number-name_of_your_bugfix_or_feature
 
-4. Create a dedicated virtual enviroment in `venv` directory for installation of python packages:
+4. Create a dedicated virtual enviroment in `venv` directory for installation of python packages::
 
     $ python -m venv venv
     $ source ./venv/bin/activate.sh
-    $ pip install -r requirements.txt    
+    $ pip install -r requirements.txt
 
 5. Make local changes to fix the bug or to implement a feature.
 


### PR DESCRIPTION
Fixes code block in point fourth that now appears as one. It should look similar to one in point sixth.

![obraz](https://github.com/DataMedSci/pymchelper/assets/128628266/ea5c154d-5246-44b9-a0b8-f9157323b25e)
