### PR TITLE
bump SH12A version in tests

### DIFF
--- a/docs/images_generation/run.sh
+++ b/docs/images_generation/run.sh
@@ -9,7 +9,7 @@ rm -f shieldhit
 rm -rf shieldhit_demo.tar.gz
 
 # fetch demo version of SHIELD-HIT12A code from main project page (extra --user-agent needed to run the code on github actions)
-wget -d --user-agent="Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0" https://shieldhit.org/download/DEMO/shield_hit12a_x86_64_demo_gfortran_v1.0.1.tar.gz -O shieldhit_demo.tar.gz
+wget -d --user-agent="Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0" https://shieldhit.org/download/DEMO/shield_hit12a_x86_64_demo_gfortran_v1.1.0.tar.gz -O shieldhit_demo.tar.gz
 
 # unpack the SHIELD-HIT12A package and extract shieldhit binary to current directory
 tar -zxvf shieldhit_demo.tar.gz

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import zipfile
 import pytest
 import requests
 
-sh12a_ver = '1.0.1'
+sh12a_ver = '1.1.0'
 linux_sh12a_demo_url = f'https://shieldhit.org/download/DEMO/shield_hit12a_x86_64_demo_gfortran_v{sh12a_ver}.tar.gz'
 windows_sh12a_demo_url = f'https://shieldhit.org/download/DEMO/shield_hit12a_win64_demo_v{sh12a_ver}.zip'
 


### PR DESCRIPTION
This pull request includes updates to the version of the SHIELD-HIT12A demo being used in the project. The most important changes involve updating the download URLs to point to the new version 1.1.0.

Version updates:

* [`docs/images_generation/run.sh`](diffhunk://#diff-3a259c800c9267ac48c06b756c5ae12f1f89c7866e41c7354c7cf623609cbdeeL12-R12): Updated the URL to download the SHIELD-HIT12A demo package from version 1.0.1 to version 1.1.0.
* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L13-R13): Updated the `sh12a_ver` variable to reflect the new version 1.1.0, which is used in constructing the URLs for downloading the demo package for both Linux and Windows.