### PR TITLE
improved win packages

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,57 +21,57 @@ jobs:
       with:
         fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.12'
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       pip install -r tests/requirements-test.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r tests/requirements-test.txt
 
-  #   - name: Lint with flake8
-  #     run: |
-  #         # stop the build if there are Python syntax errors or undefined names
-  #         flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
+    - name: Lint with flake8
+      run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
 
-  #   - name: Smoke test with pytest
-  #     run: |
-  #        pytest -k "smoke"
+    - name: Smoke test with pytest
+      run: |
+         pytest -k "smoke"
 
-  # # all tests on matrix of all possible python versions and OSes
-  # normal_test:
-  #   strategy:
-  #     matrix:
-  #       python-version: ['3.9', '3.10', '3.11', '3.12']
-  #       platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
-  #       exclude:
-  #         - platform: macos-13
-  #           python-version: '3.10'
-  #         - platform: macos-13
-  #           python-version: '3.11'
-  #         - platform: macos-13
-  #           python-version: '3.12'
-  #   runs-on: ${{ matrix.platform }}
-  #   needs: [smoke_test]
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
+  # all tests on matrix of all possible python versions and OSes
+  normal_test:
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
+        exclude:
+          - platform: macos-13
+            python-version: '3.10'
+          - platform: macos-13
+            python-version: '3.11'
+          - platform: macos-13
+            python-version: '3.12'
+    runs-on: ${{ matrix.platform }}
+    needs: [smoke_test]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       pip install -r tests/requirements-test.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r tests/requirements-test.txt
 
-  #   - name: Test with pytest
-  #     run: |
-  #        pytest -k "not slow"
+    - name: Test with pytest
+      run: |
+         pytest -k "not slow"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,57 +21,57 @@ jobs:
       with:
         fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.12'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r tests/requirements-test.txt
+  #   - name: Install dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       pip install -r tests/requirements-test.txt
 
-    - name: Lint with flake8
-      run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
+  #   - name: Lint with flake8
+  #     run: |
+  #         # stop the build if there are Python syntax errors or undefined names
+  #         flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
 
-    - name: Smoke test with pytest
-      run: |
-         pytest -k "smoke"
+  #   - name: Smoke test with pytest
+  #     run: |
+  #        pytest -k "smoke"
 
-  # all tests on matrix of all possible python versions and OSes
-  normal_test:
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
-        exclude:
-          - platform: macos-13
-            python-version: '3.10'
-          - platform: macos-13
-            python-version: '3.11'
-          - platform: macos-13
-            python-version: '3.12'
-    runs-on: ${{ matrix.platform }}
-    needs: [smoke_test]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
+  # # all tests on matrix of all possible python versions and OSes
+  # normal_test:
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.9', '3.10', '3.11', '3.12']
+  #       platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
+  #       exclude:
+  #         - platform: macos-13
+  #           python-version: '3.10'
+  #         - platform: macos-13
+  #           python-version: '3.11'
+  #         - platform: macos-13
+  #           python-version: '3.12'
+  #   runs-on: ${{ matrix.platform }}
+  #   needs: [smoke_test]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r tests/requirements-test.txt
+  #   - name: Install dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       pip install -r tests/requirements-test.txt
 
-    - name: Test with pytest
-      run: |
-         pytest -k "not slow"
+  #   - name: Test with pytest
+  #     run: |
+  #        pytest -k "not slow"

--- a/.github/workflows/release-win-exe.yml
+++ b/.github/workflows/release-win-exe.yml
@@ -44,16 +44,16 @@ jobs:
         run: cp pymchelper\VERSION .
 
       - name: Generate single-file executables for mcscripter
-        run: pyinstaller --add-data 'VERSION;pymchelper' --onefile --name mcscripter pymchelper\utils\mcscripter.py
+        run: pyinstaller --add-data 'VERSION:pymchelper' --onefile --exclude-module pytrip --name mcscripter pymchelper\utils\mcscripter.py
 
       - name: Generate single-file executables for plan2sobp
-        run: pyinstaller --add-data 'VERSION;pymchelper' --onefile --hiddenimport='pydicom.encoders.gdcm' --hiddenimport='pydicom.encoders.pylibjpeg' --hidden-import='scipy.spatial.transform._rotation_groups'  --name plan2sobp pymchelper\utils\radiotherapy\plan.py
+        run: pyinstaller --add-data 'VERSION:pymchelper' --onefile --exclude-module pytrip --hiddenimport='pydicom.encoders.gdcm' --hiddenimport='pydicom.encoders.pylibjpeg' --hidden-import='scipy.spatial.transform._rotation_groups'  --name plan2sobp pymchelper\utils\radiotherapy\plan.py
 
       - name: Generate single-file executables for runmc
-        run: pyinstaller --add-data 'VERSION;pymchelper' --onefile --name runmc pymchelper\utils\runmc.py
+        run: pyinstaller --add-data 'VERSION:pymchelper' --add-data 'pymchelper\flair\db\card.ini:pymchelper\flair\db' --exclude-module pytrip --onefile --name runmc pymchelper\utils\runmc.py
 
       - name: Generate single-file executables for convertmc
-        run: pyinstaller --add-data 'VERSION;pymchelper' --exclude-module scipy --onefile --name convertmc pymchelper\run.py
+        run: pyinstaller --add-data 'VERSION:pymchelper' --exclude-module pytrip --exclude-module scipy --onefile --name convertmc pymchelper\run.py
 
       - name: Test single-file executables
         run: |

--- a/.github/workflows/release-win-exe.yml
+++ b/.github/workflows/release-win-exe.yml
@@ -5,7 +5,7 @@ on:
     branches: [ 'release/*']
     tags: ['v*']
   pull_request:
-    branches: ['master', 'release/*']
+    branches: ['release/*']
   release:
     types: [published]
 

--- a/.github/workflows/release-win-exe.yml
+++ b/.github/workflows/release-win-exe.yml
@@ -5,7 +5,7 @@ on:
     branches: [ 'release/*']
     tags: ['v*']
   pull_request:
-    branches: [ 'release/*']
+    branches: ['master', 'release/*']
   release:
     types: [published]
 

--- a/.github/workflows/release-win-exe.yml
+++ b/.github/workflows/release-win-exe.yml
@@ -53,7 +53,7 @@ jobs:
         run: pyinstaller --add-data 'VERSION:pymchelper' --add-data 'pymchelper\flair\db\card.ini:pymchelper\flair\db' --exclude-module pytrip --onefile --name runmc pymchelper\utils\runmc.py
 
       - name: Generate single-file executables for convertmc
-        run: pyinstaller --add-data 'VERSION:pymchelper' --exclude-module pytrip --exclude-module scipy --onefile --name convertmc pymchelper\run.py
+        run: pyinstaller --add-data 'VERSION:pymchelper' --add-data 'pymchelper\flair\db\card.ini:pymchelper\flair\db' --exclude-module pytrip --exclude-module scipy --onefile --name convertmc pymchelper\run.py
 
       - name: Test single-file executables
         run: |

--- a/.github/workflows/release-win-exe.yml
+++ b/.github/workflows/release-win-exe.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: 3.12
 
+      - name: Install setuptools and wheel
+        run: pip install setuptools wheel
+
       - name: Generate VERSION file
         run: python3 setup.py --help
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release-win-exe.yml` file to enhance the build process for generating single-file executables. The most important changes include the installation of additional Python packages and the modification of `pyinstaller` commands to exclude specific modules and include necessary data files.

Enhancements to the build process:

* Added a step to install `setuptools` and `wheel` before generating the VERSION file.

Modifications to `pyinstaller` commands:

* Updated the `pyinstaller` command for `mcscripter` to exclude the `pytrip` module.
* Updated the `pyinstaller` command for `plan2sobp` to exclude the `pytrip` module.
* Updated the `pyinstaller` command for `runmc` to add data from `pymchelper\flair\db\card.ini` and exclude the `pytrip` module.
* Updated the `pyinstaller` command for `convertmc` to add data from `pymchelper\flair\db\card.ini` and exclude the `pytrip` and `scipy` modules.