### PR TITLE
improve deb package production

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,57 +21,57 @@ jobs:
       with:
         fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.12'
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       pip install -r tests/requirements-test.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r tests/requirements-test.txt
 
-  #   - name: Lint with flake8
-  #     run: |
-  #         # stop the build if there are Python syntax errors or undefined names
-  #         flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
+    - name: Lint with flake8
+      run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
 
-  #   - name: Smoke test with pytest
-  #     run: |
-  #        pytest -k "smoke"
+    - name: Smoke test with pytest
+      run: |
+         pytest -k "smoke"
 
-  # # all tests on matrix of all possible python versions and OSes
-  # normal_test:
-  #   strategy:
-  #     matrix:
-  #       python-version: ['3.9', '3.10', '3.11', '3.12']
-  #       platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
-  #       exclude:
-  #         - platform: macos-13
-  #           python-version: '3.10'
-  #         - platform: macos-13
-  #           python-version: '3.11'
-  #         - platform: macos-13
-  #           python-version: '3.12'
-  #   runs-on: ${{ matrix.platform }}
-  #   needs: [smoke_test]
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
+  # all tests on matrix of all possible python versions and OSes
+  normal_test:
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
+        exclude:
+          - platform: macos-13
+            python-version: '3.10'
+          - platform: macos-13
+            python-version: '3.11'
+          - platform: macos-13
+            python-version: '3.12'
+    runs-on: ${{ matrix.platform }}
+    needs: [smoke_test]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       pip install -r tests/requirements-test.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r tests/requirements-test.txt
 
-  #   - name: Test with pytest
-  #     run: |
-  #        pytest -k "not slow"
+    - name: Test with pytest
+      run: |
+         pytest -k "not slow"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,57 +21,57 @@ jobs:
       with:
         fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.12'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r tests/requirements-test.txt
+  #   - name: Install dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       pip install -r tests/requirements-test.txt
 
-    - name: Lint with flake8
-      run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
+  #   - name: Lint with flake8
+  #     run: |
+  #         # stop the build if there are Python syntax errors or undefined names
+  #         flake8 --count --select=E9,F63,F7,F82 --show-source --statistics pymchelper tests examples
 
-    - name: Smoke test with pytest
-      run: |
-         pytest -k "smoke"
+  #   - name: Smoke test with pytest
+  #     run: |
+  #        pytest -k "smoke"
 
-  # all tests on matrix of all possible python versions and OSes
-  normal_test:
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
-        exclude:
-          - platform: macos-13
-            python-version: '3.10'
-          - platform: macos-13
-            python-version: '3.11'
-          - platform: macos-13
-            python-version: '3.12'
-    runs-on: ${{ matrix.platform }}
-    needs: [smoke_test]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
+  # # all tests on matrix of all possible python versions and OSes
+  # normal_test:
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.9', '3.10', '3.11', '3.12']
+  #       platform: [ubuntu-latest, macos-13, windows-latest] # we stick to macOS 13, as macOS 14 comes with M1 amd architecture (and we don't have pytrip98 arm binary wheels)
+  #       exclude:
+  #         - platform: macos-13
+  #           python-version: '3.10'
+  #         - platform: macos-13
+  #           python-version: '3.11'
+  #         - platform: macos-13
+  #           python-version: '3.12'
+  #   runs-on: ${{ matrix.platform }}
+  #   needs: [smoke_test]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       fetch-depth: 0 # fetch all history, as by default only last 1 commit is fetched
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r tests/requirements-test.txt
+  #   - name: Install dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       pip install -r tests/requirements-test.txt
 
-    - name: Test with pytest
-      run: |
-         pytest -k "not slow"
+  #   - name: Test with pytest
+  #     run: |
+  #        pytest -k "not slow"

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -5,7 +5,7 @@ on:
     branches: [ 'release/*' ]
     tags: ['v*']
   pull_request:
-    branches: [ 'master', 'release/*' ]
+    branches: [ 'release/*' ]
   release:
     types: [published]
 

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -169,11 +169,11 @@ jobs:
         working-directory: debian_packages
         run: ./add_packages_to_repo.sh
 
-      - name: Setup upterm session
-        uses: owenthereal/action-upterm@v1
-        with:
-          limit-access-to-actor: true # Restrict to the user who triggered the workflow
-          limit-access-to-users: grzanka
+      # - name: Setup upterm session
+      #   uses: owenthereal/action-upterm@v1
+      #   with:
+      #     limit-access-to-actor: true # Restrict to the user who triggered the workflow
+      #     limit-access-to-users: grzanka
 
       - name: Archive directory with repository as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -41,7 +41,7 @@ jobs:
           gpg --export --armor --output public.gpg
 
       - name: check if key is expired
-        run: gpg --list-keys --with-colons --fingerprint | grep -A 1 "${{ steps.import_gpg.outputs.fingerprint }}" | grep -q expired
+        run: gpg --list-keys
 
   #     - name: Build Docker image with pyinstaller and pymchelper inside
   #       run: docker build --tag pymchelper .

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Generate deb packages
         working-directory: debian_packages
-        run: ./generate_deb_packages.sh convertmc runmc plan2sobp mcscripter
+        run: ./generate_deb_packages.sh convertmc runmc mcscripter
 
       - name: Archive deb package as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -24,22 +24,6 @@ jobs:
         with:
           fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
 
-      - name: Import GPG key from a secret variable
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-
-      - name: Print GPG user IDs and save files to be included in repository
-        working-directory: debian_packages
-        run: |
-          echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
-          echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
-          echo "name:        ${{ steps.import_gpg.outputs.name }}"
-          echo "email:       ${{ steps.import_gpg.outputs.email }}"
-          echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
-          gpg --export --armor --output public.gpg
-
       - name: Build Docker image with pyinstaller and pymchelper inside
         run: docker build --tag pymchelper .
 
@@ -169,12 +153,6 @@ jobs:
         working-directory: debian_packages
         run: ./add_packages_to_repo.sh
 
-      # - name: Setup upterm session
-      #   uses: owenthereal/action-upterm@v1
-      #   with:
-      #     limit-access-to-actor: true # Restrict to the user who triggered the workflow
-      #     limit-access-to-users: grzanka
-
       - name: Archive directory with repository as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -200,7 +178,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.7.2
-        # if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: debian_packages/public # The folder the action should deploy.

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -40,168 +40,165 @@ jobs:
           echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
           gpg --export --armor --output public.gpg
 
-      - name: check if key is expired
-        run: gpg --list-keys
+      - name: Build Docker image with pyinstaller and pymchelper inside
+        run: docker build --tag pymchelper .
 
-  #     - name: Build Docker image with pyinstaller and pymchelper inside
-  #       run: docker build --tag pymchelper .
+      - name: Generate single-file executables for mcscripter
+        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --name mcscripter pymchelper/utils/mcscripter.py
 
-  #     - name: Generate single-file executables for mcscripter
-  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --name mcscripter pymchelper/utils/mcscripter.py
+      - name: Generate single-file executables for plan2sobp
+        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --hiddenimport='pydicom.encoders.gdcm' --hiddenimport='pydicom.encoders.pylibjpeg' --hidden-import='scipy.spatial.transform._rotation_groups' --name plan2sobp pymchelper/utils/radiotherapy/plan.py
 
-  #     - name: Generate single-file executables for plan2sobp
-  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --hiddenimport='pydicom.encoders.gdcm' --hiddenimport='pydicom.encoders.pylibjpeg' --hidden-import='scipy.spatial.transform._rotation_groups' --name plan2sobp pymchelper/utils/radiotherapy/plan.py
+      - name: Generate single-file executables for runmc
+        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller runmc.spec
 
-  #     - name: Generate single-file executables for runmc
-  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller runmc.spec
+      - name: Generate single-file executables for convertmc
+        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller convertmc.spec
 
-  #     - name: Generate single-file executables for convertmc
-  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller convertmc.spec
+      - name: Test single-file executables
+        run: |
+          ls -alh ./dist/
+          ./dist/mcscripter --version
+          ./dist/plan2sobp --version
+          ./dist/runmc --version
+          ./dist/convertmc --version
+          docker run  -v `pwd`/dist:/test/ ubuntu:12.04 /test/convertmc --version
+          docker run  -v `pwd`/dist:/test/ debian:stable /test/convertmc --version
 
-  #     - name: Test single-file executables
-  #       run: |
-  #         ls -alh ./dist/
-  #         ./dist/mcscripter --version
-  #         ./dist/plan2sobp --version
-  #         ./dist/runmc --version
-  #         ./dist/convertmc --version
-  #         docker run  -v `pwd`/dist:/test/ ubuntu:12.04 /test/convertmc --version
-  #         docker run  -v `pwd`/dist:/test/ debian:stable /test/convertmc --version
+      - name: Archive executables as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: executables
+          path: ./dist
 
-  #     - name: Archive executables as artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: executables
-  #         path: ./dist
+  # upload of single-file executables to release assets
+  upload-executables:
+    runs-on: ubuntu-latest
+    needs: [build-executables]
 
-  # # upload of single-file executables to release assets
-  # upload-executables:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-executables]
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
 
-  #   steps:
-  #     - name: Checkout repository with full history
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
+      - uses: actions/download-artifact@v4
+        with:
+          name: executables
+          path: ./dist
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: executables
-  #         path: ./dist
-
-  #     - name: Add artifact with util files to the release
-  #       uses: ncipollo/release-action@v1.14.0
-  #       if: startsWith(github.ref, 'refs/tags/v')
-  #       with:
-  #         allowUpdates:  true
-  #         # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
-  #         artifacts: './dist/*'
-  #         token:  ${{ secrets.GITHUB_TOKEN }}
+      - name: Add artifact with util files to the release
+        uses: ncipollo/release-action@v1.14.0
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          allowUpdates:  true
+          # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
+          artifacts: './dist/*'
+          token:  ${{ secrets.GITHUB_TOKEN }}
 
 
-  # generate-deb-packages:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-executables]
+  generate-deb-packages:
+    runs-on: ubuntu-latest
+    needs: [build-executables]
 
-  #   steps:
-  #     - name: Checkout repository with full history
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v4
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: executables
-  #         path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: executables
+          path: ./dist
 
-  #     - name: Generate deb packages
-  #       working-directory: debian_packages
-  #       run: ./generate_deb_packages.sh convertmc runmc plan2sobp mcscripter
+      - name: Generate deb packages
+        working-directory: debian_packages
+        run: ./generate_deb_packages.sh convertmc runmc plan2sobp mcscripter
 
-  #     - name: Archive deb package as artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: deb
-  #         path: 'debian_packages/*.deb'
+      - name: Archive deb package as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb
+          path: 'debian_packages/*.deb'
 
-  # test_deb:
-  #   runs-on: ubuntu-latest
-  #   needs: [generate-deb-packages]
-  #   strategy:
-  #     matrix:
-  #       docker-tag: ['debian:12', 'debian:stable', 'ubuntu:18.04', 'ubuntu:20.04', 'ubuntu:21.04', 'ubuntu:22.04', 'ubuntu:23.04', 'ubuntu:24.04']
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: deb
-  #         path: ./
+  test_deb:
+    runs-on: ubuntu-latest
+    needs: [generate-deb-packages]
+    strategy:
+      matrix:
+        docker-tag: ['debian:12', 'debian:stable', 'ubuntu:18.04', 'ubuntu:20.04', 'ubuntu:21.04', 'ubuntu:22.04', 'ubuntu:23.04', 'ubuntu:24.04']
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: deb
+          path: ./
 
-  #     - name: Inspect artifacts
-  #       run: find . -name "*.deb" -printf 'Contents of package %p\n' -exec dpkg-deb --contents {} \;
+      - name: Inspect artifacts
+        run: find . -name "*.deb" -printf 'Contents of package %p\n' -exec dpkg-deb --contents {} \;
 
-  #     - name: Test installation
-  #       run: docker run --volume `pwd`:/pkg ${{ matrix.docker-tag }} /bin/sh -c "ldd --version; dpkg --install /pkg/pymchelper-*.deb; convertmc --version; runmc --version"
+      - name: Test installation
+        run: docker run --volume `pwd`:/pkg ${{ matrix.docker-tag }} /bin/sh -c "ldd --version; dpkg --install /pkg/pymchelper-*.deb; convertmc --version; runmc --version"
 
-  # repo_prepare:
-  #     runs-on: ubuntu-latest
-  #     needs: [generate-deb-packages]
-  #     steps:
-  #     - uses: actions/checkout@v4
+  repo_prepare:
+      runs-on: ubuntu-latest
+      needs: [generate-deb-packages]
+      steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: deb
-  #         path: debian_packages/
+      - uses: actions/download-artifact@v4
+        with:
+          name: deb
+          path: debian_packages/
 
-  #     - name: Import GPG key from a secret variable
-  #       id: import_gpg
-  #       uses: crazy-max/ghaction-import-gpg@v6
-  #       with:
-  #         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      - name: Import GPG key from a secret variable
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
-  #     - name: Print GPG user IDs and save files to be included in repository
-  #       working-directory: debian_packages
-  #       run: |
-  #         echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
-  #         echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
-  #         echo "name:        ${{ steps.import_gpg.outputs.name }}"
-  #         echo "email:       ${{ steps.import_gpg.outputs.email }}"
-  #         echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
-  #         gpg --export --armor --output public.gpg
+      - name: Print GPG user IDs and save files to be included in repository
+        working-directory: debian_packages
+        run: |
+          echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+          echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
+          echo "name:        ${{ steps.import_gpg.outputs.name }}"
+          echo "email:       ${{ steps.import_gpg.outputs.email }}"
+          echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
+          gpg --export --armor --output public.gpg
 
-  #     - name: Create reposity and add packages
-  #       working-directory: debian_packages
-  #       run: ./add_packages_to_repo.sh
+      - name: Create reposity and add packages
+        working-directory: debian_packages
+        run: ./add_packages_to_repo.sh
 
-  #     - name: Archive directory with repository as artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: repo
-  #         path: 'debian_packages/public'
+      - name: Archive directory with repository as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: 'debian_packages/public'
 
-  # repo_upload:
-  #     runs-on: ubuntu-latest
-  #     needs: [repo_prepare, test_deb]
-  #     steps:
-  #     - uses: actions/checkout@v4
+  repo_upload:
+      runs-on: ubuntu-latest
+      needs: [repo_prepare, test_deb]
+      steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: repo
-  #         path: debian_packages/public
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
+          path: debian_packages/public
 
-  #     - name: Tuning
-  #       working-directory: debian_packages
-  #       run: |
-  #         mv datamedsci.list public/
-  #         touch public/.nojekyll
+      - name: Tuning
+        working-directory: debian_packages
+        run: |
+          mv datamedsci.list public/
+          touch public/.nojekyll
 
-  #     - name: Deploy to GitHub Pages
-  #       uses: JamesIves/github-pages-deploy-action@v4.7.2
-  #       if: startsWith(github.ref, 'refs/tags/v')
-  #       with:
-  #         branch: gh-pages # The branch the action should deploy to.
-  #         folder: debian_packages/public # The folder the action should deploy.
-  #         repository-name: DataMedSci/deb_package_repository
-  #         ssh-key: ${{ secrets.DEB_REPO_PRIVATE_KEY }}
-  #         clean: true
-  #         single-commit: true
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4.7.2
+        # if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: debian_packages/public # The folder the action should deploy.
+          repository-name: DataMedSci/deb_package_repository
+          ssh-key: ${{ secrets.DEB_REPO_PRIVATE_KEY }}
+          clean: true
+          single-commit: true

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -5,7 +5,7 @@ on:
     branches: [ 'release/*' ]
     tags: ['v*']
   pull_request:
-    branches: [ 'release/*' ]
+    branches: [ 'master', 'release/*' ]
   release:
     types: [published]
 
@@ -24,115 +24,6 @@ jobs:
         with:
           fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
 
-      - name: Build Docker image with pyinstaller and pymchelper inside
-        run: docker build --tag pymchelper .
-
-      - name: Generate single-file executables for mcscripter
-        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --name mcscripter pymchelper/utils/mcscripter.py
-
-      - name: Generate single-file executables for plan2sobp
-        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --hiddenimport='pydicom.encoders.gdcm' --hiddenimport='pydicom.encoders.pylibjpeg' --hidden-import='scipy.spatial.transform._rotation_groups' --name plan2sobp pymchelper/utils/radiotherapy/plan.py
-
-      - name: Generate single-file executables for runmc
-        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller runmc.spec
-
-      - name: Generate single-file executables for convertmc
-        run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller convertmc.spec
-
-      - name: Test single-file executables
-        run: |
-          ls -alh ./dist/
-          ./dist/mcscripter --version
-          ./dist/plan2sobp --version
-          ./dist/runmc --version
-          ./dist/convertmc --version
-          docker run  -v `pwd`/dist:/test/ ubuntu:12.04 /test/convertmc --version
-          docker run  -v `pwd`/dist:/test/ debian:stable /test/convertmc --version
-
-      - name: Archive executables as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: executables
-          path: ./dist
-
-  # upload of single-file executables to release assets
-  upload-executables:
-    runs-on: ubuntu-latest
-    needs: [build-executables]
-
-    steps:
-      - name: Checkout repository with full history
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: executables
-          path: ./dist
-
-      - name: Add artifact with util files to the release
-        uses: ncipollo/release-action@v1.14.0
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          allowUpdates:  true
-          # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
-          artifacts: './dist/*'
-          token:  ${{ secrets.GITHUB_TOKEN }}
-
-
-  generate-deb-packages:
-    runs-on: ubuntu-latest
-    needs: [build-executables]
-
-    steps:
-      - name: Checkout repository with full history
-        uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: executables
-          path: ./dist
-
-      - name: Generate deb packages
-        working-directory: debian_packages
-        run: ./generate_deb_packages.sh convertmc runmc plan2sobp mcscripter
-
-      - name: Archive deb package as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: deb
-          path: 'debian_packages/*.deb'
-
-  test_deb:
-    runs-on: ubuntu-latest
-    needs: [generate-deb-packages]
-    strategy:
-      matrix:
-        docker-tag: ['debian:12', 'debian:stable', 'ubuntu:18.04', 'ubuntu:20.04', 'ubuntu:21.04', 'ubuntu:22.04', 'ubuntu:23.04', 'ubuntu:24.04']
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: deb
-          path: ./
-
-      - name: Inspect artifacts
-        run: find . -name "*.deb" -printf 'Contents of package %p\n' -exec dpkg-deb --contents {} \;
-
-      - name: Test installation
-        run: docker run --volume `pwd`:/pkg ${{ matrix.docker-tag }} /bin/sh -c "ldd --version; dpkg --install /pkg/pymchelper-*.deb; convertmc --version; runmc --version"
-
-  repo_prepare:
-      runs-on: ubuntu-latest
-      needs: [generate-deb-packages]
-      steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: deb
-          path: debian_packages/
-
       - name: Import GPG key from a secret variable
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
@@ -149,40 +40,165 @@ jobs:
           echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
           gpg --export --armor --output public.gpg
 
-      - name: Create reposity and add packages
-        working-directory: debian_packages
-        run: ./add_packages_to_repo.sh
+  #     - name: Build Docker image with pyinstaller and pymchelper inside
+  #       run: docker build --tag pymchelper .
 
-      - name: Archive directory with repository as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: repo
-          path: 'debian_packages/public'
+  #     - name: Generate single-file executables for mcscripter
+  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --name mcscripter pymchelper/utils/mcscripter.py
 
-  repo_upload:
-      runs-on: ubuntu-latest
-      needs: [repo_prepare, test_deb]
-      steps:
-      - uses: actions/checkout@v4
+  #     - name: Generate single-file executables for plan2sobp
+  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller --add-data 'pymchelper/VERSION:pymchelper' --onefile --hiddenimport='pydicom.encoders.gdcm' --hiddenimport='pydicom.encoders.pylibjpeg' --hidden-import='scipy.spatial.transform._rotation_groups' --name plan2sobp pymchelper/utils/radiotherapy/plan.py
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: repo
-          path: debian_packages/public
+  #     - name: Generate single-file executables for runmc
+  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller runmc.spec
 
-      - name: Tuning
-        working-directory: debian_packages
-        run: |
-          mv datamedsci.list public/
-          touch public/.nojekyll
+  #     - name: Generate single-file executables for convertmc
+  #       run: docker run --volume `pwd`/dist:/app/dist pymchelper:latest pyinstaller convertmc.spec
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.7.2
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: debian_packages/public # The folder the action should deploy.
-          repository-name: DataMedSci/deb_package_repository
-          ssh-key: ${{ secrets.DEB_REPO_PRIVATE_KEY }}
-          clean: true
-          single-commit: true
+  #     - name: Test single-file executables
+  #       run: |
+  #         ls -alh ./dist/
+  #         ./dist/mcscripter --version
+  #         ./dist/plan2sobp --version
+  #         ./dist/runmc --version
+  #         ./dist/convertmc --version
+  #         docker run  -v `pwd`/dist:/test/ ubuntu:12.04 /test/convertmc --version
+  #         docker run  -v `pwd`/dist:/test/ debian:stable /test/convertmc --version
+
+  #     - name: Archive executables as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: executables
+  #         path: ./dist
+
+  # # upload of single-file executables to release assets
+  # upload-executables:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-executables]
+
+  #   steps:
+  #     - name: Checkout repository with full history
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
+
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: executables
+  #         path: ./dist
+
+  #     - name: Add artifact with util files to the release
+  #       uses: ncipollo/release-action@v1.14.0
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       with:
+  #         allowUpdates:  true
+  #         # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
+  #         artifacts: './dist/*'
+  #         token:  ${{ secrets.GITHUB_TOKEN }}
+
+
+  # generate-deb-packages:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-executables]
+
+  #   steps:
+  #     - name: Checkout repository with full history
+  #       uses: actions/checkout@v4
+
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: executables
+  #         path: ./dist
+
+  #     - name: Generate deb packages
+  #       working-directory: debian_packages
+  #       run: ./generate_deb_packages.sh convertmc runmc plan2sobp mcscripter
+
+  #     - name: Archive deb package as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: deb
+  #         path: 'debian_packages/*.deb'
+
+  # test_deb:
+  #   runs-on: ubuntu-latest
+  #   needs: [generate-deb-packages]
+  #   strategy:
+  #     matrix:
+  #       docker-tag: ['debian:12', 'debian:stable', 'ubuntu:18.04', 'ubuntu:20.04', 'ubuntu:21.04', 'ubuntu:22.04', 'ubuntu:23.04', 'ubuntu:24.04']
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: deb
+  #         path: ./
+
+  #     - name: Inspect artifacts
+  #       run: find . -name "*.deb" -printf 'Contents of package %p\n' -exec dpkg-deb --contents {} \;
+
+  #     - name: Test installation
+  #       run: docker run --volume `pwd`:/pkg ${{ matrix.docker-tag }} /bin/sh -c "ldd --version; dpkg --install /pkg/pymchelper-*.deb; convertmc --version; runmc --version"
+
+  # repo_prepare:
+  #     runs-on: ubuntu-latest
+  #     needs: [generate-deb-packages]
+  #     steps:
+  #     - uses: actions/checkout@v4
+
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: deb
+  #         path: debian_packages/
+
+  #     - name: Import GPG key from a secret variable
+  #       id: import_gpg
+  #       uses: crazy-max/ghaction-import-gpg@v6
+  #       with:
+  #         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+  #     - name: Print GPG user IDs and save files to be included in repository
+  #       working-directory: debian_packages
+  #       run: |
+  #         echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+  #         echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
+  #         echo "name:        ${{ steps.import_gpg.outputs.name }}"
+  #         echo "email:       ${{ steps.import_gpg.outputs.email }}"
+  #         echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
+  #         gpg --export --armor --output public.gpg
+
+  #     - name: Create reposity and add packages
+  #       working-directory: debian_packages
+  #       run: ./add_packages_to_repo.sh
+
+  #     - name: Archive directory with repository as artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: repo
+  #         path: 'debian_packages/public'
+
+  # repo_upload:
+  #     runs-on: ubuntu-latest
+  #     needs: [repo_prepare, test_deb]
+  #     steps:
+  #     - uses: actions/checkout@v4
+
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: repo
+  #         path: debian_packages/public
+
+  #     - name: Tuning
+  #       working-directory: debian_packages
+  #       run: |
+  #         mv datamedsci.list public/
+  #         touch public/.nojekyll
+
+  #     - name: Deploy to GitHub Pages
+  #       uses: JamesIves/github-pages-deploy-action@v4.7.2
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       with:
+  #         branch: gh-pages # The branch the action should deploy to.
+  #         folder: debian_packages/public # The folder the action should deploy.
+  #         repository-name: DataMedSci/deb_package_repository
+  #         ssh-key: ${{ secrets.DEB_REPO_PRIVATE_KEY }}
+  #         clean: true
+  #         single-commit: true

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -40,6 +40,9 @@ jobs:
           echo "${{ steps.import_gpg.outputs.fingerprint }}" > key_fingerprint.txt
           gpg --export --armor --output public.gpg
 
+      - name: check if key is expired
+        run: gpg --list-keys --with-colons --fingerprint | grep -A 1 "${{ steps.import_gpg.outputs.fingerprint }}" | grep -q expired
+
   #     - name: Build Docker image with pyinstaller and pymchelper inside
   #       run: docker build --tag pymchelper .
 

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -169,6 +169,12 @@ jobs:
         working-directory: debian_packages
         run: ./add_packages_to_repo.sh
 
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
+        with:
+          limit-access-to-actor: true # Restrict to the user who triggered the workflow
+          limit-access-to-users: grzanka
+
       - name: Archive directory with repository as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -12,7 +12,7 @@ set -x
 ./tools/aptly repo add main pymchelper.deb
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
-./tools/aptly publish repo -batch main -keyring="/home/runner/.gnupg/pubring.kbx" -secret-keyring="/home/runner/.gnupg/pubring.kbx"
+./tools/aptly publish repo -batch -keyring="/home/runner/.gnupg/pubring.kbx" -secret-keyring="/home/runner/.gnupg/pubring.kbx" main
 
 ls -alh ~/.aptly/public
 

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -12,7 +12,7 @@ set -x
 ./tools/aptly repo add main pymchelper.deb
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
-./tools/aptly publish repo -batch main
+./tools/aptly publish repo -batch main -gpg-key="C172E55F3B9F9C5B" -keyring="/home/runner/.gnupg/pubring.kbx" -secret-keyring="/home/runner/.gnupg/pubring.kbx"
 
 ls -alh ~/.aptly/public
 

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -12,7 +12,13 @@ set -x
 ./tools/aptly repo add main pymchelper.deb
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
-./tools/aptly publish repo -batch -keyring="/home/runner/.gnupg/pubring.kbx" -secret-keyring="/home/runner/.gnupg/pubring.kbx" main
+
+gpg --quick-set-expire A78079C33817ABFE9513BF99C172E55F3B9F9C5B 1y
+
+gpg --list-secret-keys
+gpg --list-keys --keyid-format LONG
+
+./tools/aptly publish repo main
 
 ls -alh ~/.aptly/public
 

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -13,11 +13,6 @@ set -x
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
 
-gpg --quick-set-expire A78079C33817ABFE9513BF99C172E55F3B9F9C5B 0
-
-gpg --list-secret-keys
-gpg --list-keys --keyid-format LONG
-
 ./tools/aptly publish repo main
 
 ls -alh ~/.aptly/public

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -12,7 +12,7 @@ set -x
 ./tools/aptly repo add main pymchelper.deb
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
-./tools/aptly publish repo -batch main -gpg-key="C172E55F3B9F9C5B" -keyring="/home/runner/.gnupg/pubring.kbx" -secret-keyring="/home/runner/.gnupg/pubring.kbx"
+./tools/aptly publish repo -batch main -keyring="/home/runner/.gnupg/pubring.kbx" -secret-keyring="/home/runner/.gnupg/pubring.kbx"
 
 ls -alh ~/.aptly/public
 

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -7,9 +7,11 @@ set -x
 ./tools/aptly repo create -distribution="stable" -component="main" main
 ./tools/aptly repo add main pymchelper-convertmc.deb
 ./tools/aptly repo add main pymchelper-runmc.deb
-./tools/aptly repo add main pymchelper-plan2sobp.deb
+#./tools/aptly repo add main pymchelper-plan2sobp.deb  # skipping as its exceeding the 100MB limit
 ./tools/aptly repo add main pymchelper-mcscripter.deb
 ./tools/aptly repo add main pymchelper.deb
+gpg --list-secret-keys
+gpg --list-keys --keyid-format LONG
 ./tools/aptly publish repo -batch main
 
 ls -alh ~/.aptly/public

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -3,6 +3,7 @@
 # Print commands and their arguments as they are executed
 set -x
 
+./tools/aptly version
 ./tools/aptly repo create -distribution="stable" -component="main" main
 ./tools/aptly repo add main pymchelper-convertmc.deb
 ./tools/aptly repo add main pymchelper-runmc.deb
@@ -11,7 +12,7 @@ set -x
 ./tools/aptly repo add main pymchelper.deb
 ./tools/aptly publish repo -batch main
 
-ls -alh ~/.aptly/public      
+ls -alh ~/.aptly/public
 
 mv ~/.aptly/public .
 

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -10,7 +10,6 @@ set -x
 #./tools/aptly repo add main pymchelper-plan2sobp.deb  # skipping as its exceeding the 100MB limit
 ./tools/aptly repo add main pymchelper-mcscripter.deb
 ./tools/aptly repo add main pymchelper.deb
-gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
 
 ./tools/aptly publish repo main

--- a/debian_packages/add_packages_to_repo.sh
+++ b/debian_packages/add_packages_to_repo.sh
@@ -13,7 +13,7 @@ set -x
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG
 
-gpg --quick-set-expire A78079C33817ABFE9513BF99C172E55F3B9F9C5B 1y
+gpg --quick-set-expire A78079C33817ABFE9513BF99C172E55F3B9F9C5B 0
 
 gpg --list-secret-keys
 gpg --list-keys --keyid-format LONG

--- a/debian_packages/tools/get_aptly.sh
+++ b/debian_packages/tools/get_aptly.sh
@@ -3,11 +3,11 @@
 # Print commands and their arguments as they are executed
 set -x
 
-wget --quiet https://github.com/aptly-dev/aptly/releases/download/v1.4.0/aptly_1.4.0_linux_amd64.tar.gz
-tar -zxf aptly_1.4.0_linux_amd64.tar.gz
+wget --quiet https://github.com/aptly-dev/aptly/releases/download/v1.5.0/aptly_1.5.0_linux_amd64.tar.gz
+tar -zxf aptly_1.5.0_linux_amd64.tar.gz
 
-mv ./aptly_1.4.0_linux_amd64/aptly .
+mv ./aptly_1.5.0_linux_amd64/aptly .
 
 # cleaning
-rm aptly_1.4.0_linux_amd64.tar.gz
-rm --recursive --force ./aptly_1.4.0_linux_amd64
+rm aptly_1.5.0_linux_amd64.tar.gz
+rm --recursive --force ./aptly_1.5.0_linux_amd64


### PR DESCRIPTION
This pull request includes several updates to the Debian package management scripts and workflow files. The most important changes include removing the `plan2sobp` package from the release process, updating the `aptly` tool to a newer version, and adding a GPG key listing step during the repository publication process.

### Changes related to package management:

* [`.github/workflows/release-deb.yml`](diffhunk://#diff-53e0e1759d62bb2c60e86f9bf16cdcc99048213ea883af7900ffb7ddf2fd4655L99-R99): Removed the `plan2sobp` package from the `generate_deb_packages.sh` script to avoid exceeding the size limit.
* [`debian_packages/add_packages_to_repo.sh`](diffhunk://#diff-c6881e82f3bc0945a0d8691b3097d61194ed534c850e676579209d47adb0ca7bR6-R15): Commented out the addition of the `plan2sobp` package due to its size and added a step to list GPG keys before publishing the repository.

### Changes related to tool updates:

* [`debian_packages/tools/get_aptly.sh`](diffhunk://#diff-57b02fdf1771789c21ae60f0a64dc14b0cb50acbbe7e0f8cad46e2e816801e87L6-R13): Updated the `aptly` tool from version 1.4.0 to 1.5.0 to ensure compatibility and access to new features.