### PR TITLE
Estimators should be sorted by file names

### DIFF
--- a/pymchelper/input_output.py
+++ b/pymchelper/input_output.py
@@ -249,7 +249,7 @@ def convertfrompattern(pattern, outputdir, converter_name, options, error=ErrorE
     :param nan: if True, NaN (not a number) are excluded when averaging data.
     :return:
     """
-    list_of_matching_files = glob(pattern)
+    list_of_matching_files = sorted(glob(pattern))
 
     core_names_dict = group_input_files(list_of_matching_files)
 

--- a/pymchelper/input_output.py
+++ b/pymchelper/input_output.py
@@ -189,7 +189,7 @@ def frompattern(pattern: str, error: ErrorEstimate = ErrorEstimate.stderr, nan: 
     """
 
     try:
-        list_of_matching_files = glob(pattern)
+        list_of_matching_files = sorted(glob(pattern))
     except TypeError as e:  # noqa: F841
         list_of_matching_files = pattern
 

--- a/tests/test_frompattern.py
+++ b/tests/test_frompattern.py
@@ -1,0 +1,15 @@
+import pytest
+from pymchelper.input_output import frompattern
+
+
+@pytest.fixture
+def shieldhit_pattern() -> str:
+    """Fixture for SHIELD-HIT file pattern"""
+    return "tests/res/shieldhit/generated/many/msh/aen_*.bdo"
+
+
+def test_estimators_are_sorted_by_names(shieldhit_pattern: str) -> None:
+    """Test if frompattern returns estimators sorted by name"""
+    averaged_estimators = frompattern(pattern=shieldhit_pattern)
+    estimator_names = [estimator.file_corename for estimator in averaged_estimators]
+    assert estimator_names == sorted(estimator_names), "Estimators are not sorted by file names"


### PR DESCRIPTION
This pull request includes changes to ensure that files matched by patterns are sorted, and adds a new test to verify this functionality. The most important changes include modifying the `frompattern` and `convertfrompattern` functions to sort the list of matching files, and adding a test to ensure that the sorting works correctly.

Changes to file sorting:

* [`pymchelper/input_output.py`](diffhunk://#diff-749465d89330bee09b9fa293e8a8d9c06f1f5962386d06a57e056c5ea90d8a78L192-R192): Modified the `frompattern` function to sort the list of matching files returned by `glob`.
* [`pymchelper/input_output.py`](diffhunk://#diff-749465d89330bee09b9fa293e8a8d9c06f1f5962386d06a57e056c5ea90d8a78L252-R252): Modified the `convertfrompattern` function to sort the list of matching files returned by `glob`.

Testing:

* [`tests/test_frompattern.py`](diffhunk://#diff-6a230dcd03e5266f679b6792c1bf4fc36aed85a4f08f56aa8e5bc2f530587d31R1-R15): Added a new test to verify that the `frompattern` function returns estimators sorted by their file names.