### PR TITLE
fix requirements for plan2sobp

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,6 +28,8 @@ In order to use all feautures (i.e. all available converters), use::
 
     pip install "pymchelper[full]"
 
+To install as well `plan2sobp` program type: ``pip install "pymchelper[dicom]"``
+
 
 Python package (Debian based Linux)
 -----------------------------------

--- a/pymchelper/utils/radiotherapy/plan.py
+++ b/pymchelper/utils/radiotherapy/plan.py
@@ -529,16 +529,16 @@ def load_PLD_IBA(file_pld: Path, scaling=1.0) -> Plan:
 
 def load_DICOM_VARIAN(file_dcm: Path, scaling=1.0) -> Plan:
     """Load varian type dicom plans."""
+    p = Plan()
     try:
         import pydicom as dicom
     except ImportError:
         logger.error("pydicom is not installed, cannot read DICOM files.")
         logger.error("Please install pymchelper[dicom] or pymchelper[all] to us this feature.")
-        return None
+        return p
     ds = dicom.dcmread(file_dcm)
     # Total number of energy layers used to produce SOBP
 
-    p = Plan()
     p.patient_id = ds['PatientID'].value
     p.patient_name = ds['PatientName'].value
     p.patient_initals = ""

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ EXTRAS_REQUIRE = {
     'image': ['matplotlib'],
     'excel': ['xlwt'],
     'hdf': ['h5py'],
-    'dicom': ["pydicom"],
+    'dicom': ["pydicom", "scipy"],
     'pytrip': [
         'scipy',
         "pytrip98>=3.8.0,<3.9.0 ; platform_system == 'Darwin' and python_version >= '3.11'",
@@ -79,10 +79,8 @@ EXTRAS_REQUIRE['full'].extend(["hipsterplot", "bashplotlib"])  # these are neede
 # |---------------------------------------------------|
 # see https://www.python.org/dev/peps/pep-0508/ for language specification
 install_requires = [
-    "numpy>=1.26 ; python_version == '3.12'",
-    "numpy>=1.23.3 ; python_version == '3.11'",
-    "numpy>=1.21 ; python_version == '3.10'",
-    "numpy>=1.20,<1.27.0 ; python_version == '3.9'"
+    "numpy>=1.26 ; python_version == '3.12'", "numpy>=1.23.3 ; python_version == '3.11'",
+    "numpy>=1.21 ; python_version == '3.10'", "numpy>=1.20,<1.27.0 ; python_version == '3.9'"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
To properly install plan2sobp you need to install pymchelper via pipx install pymchelper[dicom] instead of pipx install pymchelper. The last command will install only basic features of the converter, namely conversion to plain text files.

This pull request includes several changes to improve the handling of optional dependencies and enhance the readability of the code. The most important changes include adding error handling for missing dependencies, updating the installation instructions, and improving code formatting.

Error handling for missing dependencies:

* [`pymchelper/utils/radiotherapy/plan.py`](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fR85-R91): Added error handling for missing `scipy` and `pydicom` dependencies in the `__init__` and `load_DICOM_VARIAN` methods, respectively. [[1]](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fR85-R91) [[2]](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fR532-L530)

Installation instructions:

* [`docs/install.rst`](diffhunk://#diff-379774f5c6e537f2001c951863c6ac577b56eb5c6e61cc581dce95143760ff36R31-R32): Updated the installation instructions to include the `plan2sobp` program by specifying the `pymchelper[dicom]` option.

Code formatting improvements:

* [`pymchelper/utils/radiotherapy/plan.py`](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fL620-R644): Reformatted argument definitions in the `main` function for better readability. [[1]](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fL620-R644) [[2]](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fL638-R654) [[3]](diffhunk://#diff-9b7e35ad93b69aebcc8a4478c954453c99f49abb4402bd88605f07b83a5d0b1fL675-R690)
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L82-R83): Consolidated `numpy` version specifications for different Python versions into a more compact format.

Dependency updates:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L37-R37): Updated the `dicom` extra to include both `pydicom` and `scipy` packages.