### PR TITLE
Add page_number calculation to FLUKA

### DIFF
--- a/pymchelper/readers/fluka.py
+++ b/pymchelper/readers/fluka.py
@@ -58,6 +58,7 @@ class FlukaReader(Reader):
             for det_no, detector in enumerate(usr_object.detector):
                 page = Page(estimator=estimator)
                 page.title = detector.name
+                page.page_number = det_no
                 # USRBIN doesn't support differential binning type, only spatial binning is allowed
 
                 axes_description = UsrbinScoring.get_axes_description(detector.type)


### PR DESCRIPTION
This pull request includes a small change to the `pymchelper/readers/fluka.py` file. The change adds a new attribute, `page_number`, to the `page` object within the `parse_usrbin` method. 

* [`pymchelper/readers/fluka.py`](diffhunk://#diff-aa01333662d3948b79b017591956546ce5ebb46013eb380095d6c60e87c22074R61): Added `page_number` attribute to the `page` object to store the detector number.