### PR TITLE
Fix, double diff SH12 yields misshapen arrays after convertmc 

### DIFF
--- a/pymchelper/writers/plots.py
+++ b/pymchelper/writers/plots.py
@@ -47,7 +47,7 @@ class PlotDataWriter(Writer):
             # each axis may have different number of points, this is what we store here:
             axis_data_columns_1d = [page.plot_axis(i).data for i in axis_numbers]
 
-            # Define ravel_order, F for fortran-style else C-style.
+            # Define ravel_order, F for Fortran-style else C-style.
             ravel_order = 'F' if page.estimator.file_format in {'bdo2016', 'bdo2019', 'fluka_binary'} else 'C'
 
             # now we calculate running index for each axis

--- a/pymchelper/writers/shieldhit.py
+++ b/pymchelper/writers/shieldhit.py
@@ -195,7 +195,7 @@ class TxtWriter:
 
             # Define ravel_order 'F' for fortran style else C style.
             ravel_order = 'F' if page.estimator.file_format in {'bdo2016', 'bdo2019', 'fluka_binary'} else 'C'
-            # Apply ravel_orders to lists and det_error.
+            # Apply ravel_order to lists and det_error.
             det_error = [None] * page.data.size if page.error is None else page.error.ravel(order=ravel_order)
             for x, y, z, v, e in zip(
                 xlist.ravel(order=ravel_order),


### PR DESCRIPTION
Suggested fix for array reshape. Only tested for plotdata convertmc command. Ravel commands was missing order arguement, and linear raw data was appended instead of the raveled page data.