### PR TITLE
Add support for binary wheels of scipy in installation steps

### DIFF
--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -34,6 +34,7 @@ jobs:
               "$PYBIN" -m pip install --upgrade pip
               # Prefer binary wheels globally for heavy deps, then install project deps
               PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary numpy
+              PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary scipy
               PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary h5py
               "$PYBIN" -m pip install -e .[full]
               "$PYBIN" -m pip install nuitka==2.8 wheel
@@ -81,6 +82,7 @@ jobs:
               "$PYBIN" -m pip install --upgrade pip
               # Prefer binary wheels globally for heavy deps, then install project deps
               PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary numpy
+              PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary scipy
               PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary h5py
               "$PYBIN" -m pip install -e .[full]
               "$PYBIN" -m pip install nuitka==2.8 wheel
@@ -130,6 +132,7 @@ jobs:
               "$PYBIN" -m pip install --upgrade pip
               # Prefer binary wheels globally for heavy deps, then install project deps
               PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary numpy
+              PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary scipy
               PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary h5py
               "$PYBIN" -m pip install -e .[full]
               "$PYBIN" -m pip install nuitka==2.8 wheel

--- a/docs/technical.rst
+++ b/docs/technical.rst
@@ -76,6 +76,7 @@ The executables are built inside a manylinux2014 Docker container to ensure maxi
         "$PYBIN" -m pip install --upgrade pip
         # Prefer binary wheels globally for heavy deps, then install project deps
         PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary numpy
+        PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary scipy
         PIP_ONLY_BINARY=:all: "$PYBIN" -m pip install --prefer-binary h5py
         "$PYBIN" -m pip install -e .[full]
         "$PYBIN" -m pip install nuitka==2.8 wheel


### PR DESCRIPTION
This pull request updates the build and release workflow to ensure that `scipy` is installed as a binary wheel alongside other heavy dependencies, both in the CI configuration and the technical documentation. This change helps streamline the installation process and improve build reliability for environments where compiling `scipy` from source is undesirable.

Build workflow updates:

* Added installation of `scipy` as a binary wheel in three separate steps in the `.github/workflows/release-deb.yml` file to match the handling of other heavy dependencies like `numpy` and `h5py`. [[1]](diffhunk://#diff-53e0e1759d62bb2c60e86f9bf16cdcc99048213ea883af7900ffb7ddf2fd4655R37) [[2]](diffhunk://#diff-53e0e1759d62bb2c60e86f9bf16cdcc99048213ea883af7900ffb7ddf2fd4655R85) [[3]](diffhunk://#diff-53e0e1759d62bb2c60e86f9bf16cdcc99048213ea883af7900ffb7ddf2fd4655R135)

Documentation update:

* Updated the code sample in `docs/technical.rst` to include binary wheel installation of `scipy`, ensuring documentation matches the new workflow.