### PR TITLE
Drop Python 3.9 support, bump pytest to 9.0.3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 - Command-line tools: `convertmc`, `runmc`, `mcscripter`, `plan2sobp`
 
 ### Technology Stack
-- **Language**: Python 3.9-3.14
+- **Language**: Python 3.10-3.14
 - **Build System**: setuptools with setuptools-scm for versioning
 - **Key Dependencies**: numpy (core), matplotlib (imaging), h5py (HDF5), pydicom (DICOM), xlwt (Excel)
 - **Testing**: pytest with pytest-rerunfailures
@@ -144,7 +144,7 @@ cd docs && make html
 
 ### Platform Support
 - Must work on Linux, macOS, and Windows
-- CI tests on all three platforms with Python 3.9-3.14
+- CI tests on all three platforms with Python 3.10-3.14
 - Be mindful of path separators and platform-specific issues
 
 ### Dependencies Management
@@ -156,7 +156,7 @@ cd docs && make html
 ## CI/CD and Automation
 
 ### GitHub Actions
-- Tests run automatically on Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+- Tests run automatically on Python 3.10, 3.11, 3.12, 3.13, 3.14
 - Tests run on Linux, macOS, and Windows
 - Flake8 syntax checks run automatically
 - All checks must pass before merging

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,7 +50,7 @@ jobs:
   normal_test:
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     needs: [smoke_test]

--- a/.github/workflows/release-pip.yml
+++ b/.github/workflows/release-pip.yml
@@ -17,7 +17,7 @@ jobs:
   full_test:
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -121,7 +121,7 @@ We assume you are familiar with GIT source control system.
 
 11. Submit a pull request through the GitHub website to the ``master`` branch.
 
-12. GitHub Actions will automatically run tests on multiple Python versions (3.9-3.14) and platforms (Linux, macOS, Windows). Check the status and fix any failures by pushing additional commits to your branch.
+12. GitHub Actions will automatically run tests on multiple Python versions (3.10-3.14) and platforms (Linux, macOS, Windows). Check the status and fix any failures by pushing additional commits to your branch.
 
 
 Pull Request Guidelines
@@ -139,7 +139,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 3. **Pass CI checks**: Ensure all automated tests pass on:
    
-   - All supported Python versions (3.9, 3.10, 3.11, 3.12, 3.13, 3.14)
+   - All supported Python versions (3.10, 3.11, 3.12, 3.13, 3.14)
    - All platforms (Linux, macOS, Windows)
    - Flake8 syntax checks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pymchelper"
 dynamic = ["version"]
 description = "Python toolkit for SHIELD-HIT12A and FLUKA"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
     {name = "pymchelper team", email = "leszek.grzanka@gmail.com"}
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: MacOS",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -55,15 +54,14 @@ full = [
     "bashplotlib",
 ]
 test = [
-    "pytest==8.4.2",
+    "pytest==9.0.3",
     "pytest-rerunfailures",
     "flake8==7.3.0",
     "sphinx>=7.0",
     "mcpl==1.6.2",
     "yapf==0.43.0",
     "scipy",
-    "pre-commit==3.7.1 ; python_version < '3.10'",
-    "pre-commit==4.5.0 ; python_version >= '3.10'",
+    "pre-commit==4.5.0",
 ]
 dev = [
     "pymchelper[full,test]",


### PR DESCRIPTION
## Summary
- Dependabot PR #893 bumps `pytest` to 9.0.3, but pytest 9.x requires `Requires-Python >=3.10`, so `pip install pymchelper[test]` fails on Python 3.9 and cascades into cancelling the rest of the CI matrix (fail-fast).
- Python 3.9 reached end-of-life on 2025-10-31, so this drops 3.9 support instead of pinning pytest back.

## Changes
- `pyproject.toml`: `requires-python = ">=3.10"`, drop the 3.9 classifier, bump `pytest` to `9.0.3`, simplify the now-single `pre-commit==4.5.0` pin (removes the dead `python_version < '3.10'` marker)
- `.github/workflows/python-app.yml` / `release-pip.yml`: drop `3.9` from the test matrices
- `docs/contributing.rst`, `.github/copilot-instructions.md`: update supported-version mentions

Closes #896. Supersedes #893 (which can be closed once this merges).

## Test plan
- [x] `pip install -e .[full,test]` succeeds on Python 3.12 with pytest 9.0.3
- [x] `pytest -k "not slow" --reruns 2` → 140 passed, 2 skipped, 3 deselected
- [x] `pytest -k "smoke" --reruns 2` → 32 passed, 2 skipped
- [x] `flake8 --count --select=E9,F63,F7,F82 ...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)